### PR TITLE
Don't linline filmicrgb.c#convert_to_spline_v3

### DIFF
--- a/src/iop/filmicrgb.c
+++ b/src/iop/filmicrgb.c
@@ -382,7 +382,7 @@ inline static gboolean dt_iop_filmic_rgb_compute_spline(const dt_iop_filmicrgb_p
 
 // BEWARE: convert_to_spline_v3 supports up to v6 of params (see legacy_params)
 // convert parameters from spline v1 or v2 to spline v3
-static inline void convert_to_spline_v3(dt_iop_filmicrgb_params_t* n)
+static void convert_to_spline_v3(dt_iop_filmicrgb_params_t* n)
 {
   if(n->spline_version == DT_FILMIC_SPLINE_VERSION_V3)
     return;


### PR DESCRIPTION
Inlining the function breaks parameter updates with GCC 13.2.0

Fixes https://github.com/darktable-org/darktable/issues/17420